### PR TITLE
Fix for building with gcc/g++ 4.7.x

### DIFF
--- a/log.cpp
+++ b/log.cpp
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdarg.h>
+#include <unistd.h>
 
 namespace openbfdd
 {


### PR DESCRIPTION
The error you get when building is:

error: ‘getpid’ was not declared in this scope

This happends because unistd.h is not included by default anymore:

Avoid polluting the global namespace and do not include <unistd.h>.

http://gcc.gnu.org/gcc-4.7/changes.html

Like with gcc/g++ 4.7.x on Ubuntu 12.10.
