### PR TITLE
Fixes to compile on FreeBSD 10.1-RELEASE

### DIFF
--- a/Logger.cpp
+++ b/Logger.cpp
@@ -4,6 +4,7 @@
 * Distributed under the FreeBSD License - see LICENSE
 ***************************************************************/
 #include "standard.h"
+#include "threads.h"
 #include "Logger.h"
 #include "LogException.h"
 #include "compat.h"

--- a/SchedulerBase.cpp
+++ b/SchedulerBase.cpp
@@ -4,6 +4,7 @@
 * Distributed under the FreeBSD License - see LICENSE
 ***************************************************************/
 #include "common.h"
+#include "threads.h"
 #include "SchedulerBase.h"
 #include "utils.h"
 #include "SmartPointer.h"

--- a/SmartPointer.cpp
+++ b/SmartPointer.cpp
@@ -7,6 +7,7 @@
 #include "standard.h"
 #include "SmartPointer.h"
 #include <unistd.h>
+#include <iostream>
 
 using namespace std;
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -4,6 +4,7 @@
 * Distributed under the FreeBSD License - see LICENSE
 ***************************************************************/
 #include "common.h"
+#include "threads.h"
 #include "utils.h"
 #include "compat.h"
 #include <errno.h>
@@ -538,7 +539,7 @@ const char* Ip4ToString(in_addr_t address, uint16_t port)
           (uint8_t)data[1],
           (uint8_t)data[2],
           (uint8_t)data[3],
-          (unsigned int)port
+          (unsigned short)port
          );
 
   return buf;


### PR DESCRIPTION
Found this project while trying to signal a Juniper router from a FreeBSD box.  The latest released packages and git sources wouldn't compile cleanly on the system, but a little hacking got it to run.  Figured I'd share in case it helps someone.

I am BY NO MEANS a C++ programmer (perl/java is my thing), so if these fixes are weird/inefficient feel free to reject.  They were IMNSHO pretty minor:

Added missing includes for files needing <pthread.h> by adding threads.h to the cpp files that were throwing errors about missing pthread symbols.  threads.h has a "pragma once", so that seemed to be the least destructive way to do it.

Fixed a small compiler warning about unsigned short (vs int).

Added <iostream> to quiet a warning about "namespace std" (stackexchange to the rescue on that; I've no idea what this error was about).

Left other compiler warnings about unused fields alone (several are acknowledged in the source, so choosing not to mess with them).

Source now builds with only the aforementioned warnings, and the binaries run (I've confirmed basic interop with our Juniper gear).  Yay!